### PR TITLE
Trustar: Bugfix - Fix coloring in widget for get report output

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Bug fix in the output table for the ‘get report’ action

--- a/trustar.json
+++ b/trustar.json
@@ -12,7 +12,7 @@
     "product_vendor": "TruSTAR Technology",
     "product_name": "TruSTAR",
     "product_version_regex": ".*",
-    "min_phantom_version": "5.0.0",
+    "min_phantom_version": "5.1.0",
     "logo": "logo_trustar.svg",
     "logo_dark": "logo_trustar_dark.svg",
     "python_version": "3",

--- a/trustar_connector.py
+++ b/trustar_connector.py
@@ -204,7 +204,7 @@ class TrustarConnector(BaseConnector):
             ret_val = self._generate_api_token(action_result)
 
             if phantom.is_fail(ret_val):
-                self.debug_prin("Something went wrong while generating the token")
+                self.debug_print("Something went wrong while generating the token")
                 return action_result.get_status(), None
 
             headers.update({

--- a/trustar_connector.py
+++ b/trustar_connector.py
@@ -204,6 +204,7 @@ class TrustarConnector(BaseConnector):
             ret_val = self._generate_api_token(action_result)
 
             if phantom.is_fail(ret_val):
+                self.debug_prin("Something went wrong while generating the token")
                 return action_result.get_status(), None
 
             headers.update({

--- a/trustar_connector.py
+++ b/trustar_connector.py
@@ -1133,6 +1133,7 @@ class TrustarConnector(BaseConnector):
         :param param: dictionary of input parameters
         :return: status success/failure
         """
+        self.debug_print("_list_observable_types function started")
         action_result = self.add_action_result(ActionResult(dict(param)))
         summary_data = action_result.update_summary({})
 
@@ -1142,6 +1143,7 @@ class TrustarConnector(BaseConnector):
             action_result.add_data(type)
 
         summary_data["observable_type_count"] = len(consts.TRUSTAR_OBSERVABLE_TYPES)
+        self.debug_print("Observable type count is {}".format(summary_data["observable_type_count"]))
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/trustar_display_report_details.html
+++ b/trustar_display_report_details.html
@@ -102,6 +102,13 @@ and limitations under the License.
     background-image: none;
     }
 
+    body.dark-theme .trustar #report_description_detail > div > pre {
+        color: white;
+    }
+    body.dark-theme .trustar #extracted_iocs > div > pre {
+        color: white;
+    }
+
     .trustar .indicators-div {
     }
 


### PR DESCRIPTION
Please ensure your pull request (PR) adheres to the following guidelines:

- Please refer to our contributing documentation for any questions on submitting a pull request, link: [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md)

## Pull Request Checklist

#### Please check if your PR fulfills the following requirements:
- [x] Testing of all the changes has been performed (for bug fixes / features)
- [x] The readme.html has been reviewed and added / updated if needed (for bug fixes / features)
- [x] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
- [x] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
- [x] Verify all checks are passing.
- [x] Do NOT use the `next` branch of the forked repo. Create separate feature branch for raising the PR.
- [x] Do NOT submit updates to dependencies unless it fixes an issue.
## Pull Request Type

#### Please check the type of change your PR introduces:
- [ ] New App
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe): 

## Release Notes (REQUIRED)
- Fix Coloring for **get report** action widget

## What is the current behavior? (OPTIONAL)
- Report content is not visible in dark theme without selection

## What is the new behavior? (OPTIONAL)
- Widget content is not visible in dark theme

## Screenshots (if relevant)

### Before
<img width="932" alt="Screenshot 2022-02-25 at 14 38 35" src="https://user-images.githubusercontent.com/2430239/155725266-8ef1e038-f8d6-499b-a855-995288c4a762.png">

### After
<img width="932" alt="Screenshot 2022-02-25 at 14 37 39" src="https://user-images.githubusercontent.com/2430239/155725280-dae617e9-0f62-4b4e-8f9d-664a5ca6b73e.png">


---
Thanks for contributing!
